### PR TITLE
Fix CA1515 & CA1852 warnings

### DIFF
--- a/ClockifyExport.Cli/.editorconfig
+++ b/ClockifyExport.Cli/.editorconfig
@@ -1,0 +1,2 @@
+[*.{cs,vb}]
+dotnet_code_quality.CA1852.ignore_internalsvisibleto = true

--- a/ClockifyExport.Cli/AppCommand.cs
+++ b/ClockifyExport.Cli/AppCommand.cs
@@ -16,7 +16,7 @@ namespace ClockifyExport.Cli;
 /// <param name="csvParser">Injected <see cref="ICsvParser"/> instance.</param>
 /// <param name="timeEntryAggregator">Injected <see cref="ITimeEntryAggregator"/> instance.</param>
 /// <param name="exporterProvider">Injected <see cref="ExporterProvider"/> instance.</param>
-public class AppCommand(
+internal sealed class AppCommand(
     IApiClient apiClient,
     ICsvParser csvParser,
     ITimeEntryAggregator timeEntryAggregator,

--- a/ClockifyExport.Cli/Clockify/ApiClient.cs
+++ b/ClockifyExport.Cli/Clockify/ApiClient.cs
@@ -6,7 +6,7 @@ namespace ClockifyExport.Cli.Clockify;
 /// <summary>
 /// Provides access to the Clockify API.
 /// </summary>
-public class ApiClient(HttpClient httpClient) : IApiClient
+internal sealed class ApiClient(HttpClient httpClient) : IApiClient
 {
     private const string dateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffZ";
 

--- a/ClockifyExport.Cli/Clockify/ClockifyTimeEntry.cs
+++ b/ClockifyExport.Cli/Clockify/ClockifyTimeEntry.cs
@@ -5,7 +5,7 @@ namespace ClockifyExport.Cli.Clockify;
 /// <summary>
 /// Represents a time entry from a Clockify shared report.
 /// </summary>
-public record class ClockifyTimeEntry
+internal sealed record class ClockifyTimeEntry
 {
     /// <summary>
     /// Date of the time entry. Non-parsed string as in the CSV.

--- a/ClockifyExport.Cli/Clockify/CsvParser.cs
+++ b/ClockifyExport.Cli/Clockify/CsvParser.cs
@@ -6,7 +6,7 @@ namespace ClockifyExport.Cli.Clockify;
 /// <summary>
 /// Parses CSV data from Clockify.
 /// </summary>
-public class CsvParser : ICsvParser
+internal sealed class CsvParser : ICsvParser
 {
     ///<inheritdoc />
     public IReadOnlyList<ClockifyTimeEntry> ParseSharedReportCsv(string csv)

--- a/ClockifyExport.Cli/Clockify/IApiClient.cs
+++ b/ClockifyExport.Cli/Clockify/IApiClient.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Provides access to the Clockify API.
 /// </summary>
-public interface IApiClient
+internal interface IApiClient
 {
     /// <summary>
     /// Gets a shared report in CSV format.

--- a/ClockifyExport.Cli/Clockify/ICsvParser.cs
+++ b/ClockifyExport.Cli/Clockify/ICsvParser.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Parses CSV data from Clockify.
 /// </summary>
-public interface ICsvParser
+internal interface ICsvParser
 {
     /// <summary>
     /// Parses CSV data from a shared report.

--- a/ClockifyExport.Cli/ClockifyExport.Cli.csproj
+++ b/ClockifyExport.Cli/ClockifyExport.Cli.csproj
@@ -44,6 +44,11 @@
   <ItemGroup>
     <None Include="../LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
     <None Include="../README.md" Pack="true" PackagePath="README.md" />
+    <None Include="./.editorconfig" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EditorConfigFiles Remove="./.editorconfig" />
   </ItemGroup>
   
 </Project>

--- a/ClockifyExport.Cli/Export/CsvExporter.cs
+++ b/ClockifyExport.Cli/Export/CsvExporter.cs
@@ -8,7 +8,7 @@ namespace ClockifyExport.Cli.Export;
 /// <summary>
 /// Exports data to a CSV string.
 /// </summary>
-public class CsvExporter : IExporter
+internal sealed class CsvExporter : IExporter
 {
     /// <inheritdoc />
     public string Export(IEnumerable<GroupedTimeEntry> timeEntries)

--- a/ClockifyExport.Cli/Export/ExportFormat.cs
+++ b/ClockifyExport.Cli/Export/ExportFormat.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Indicates the format in which data should be exported.
 /// </summary>
-public enum ExportFormat
+internal enum ExportFormat
 {
     /// <summary>
     /// CSV format.

--- a/ClockifyExport.Cli/Export/ExportServiceCollectionExtensions.cs
+++ b/ClockifyExport.Cli/Export/ExportServiceCollectionExtensions.cs
@@ -5,7 +5,7 @@ namespace ClockifyExport.Cli.Export;
 /// <summary>
 /// Extension methods for <see cref="IServiceCollection"/> to add exporters.
 /// </summary>
-public static class ExportServiceCollectionExtensions
+internal static class ExportServiceCollectionExtensions
 {
     /// <summary>
     /// Adds all classes required by exporters to the service collection.

--- a/ClockifyExport.Cli/Export/ExporterProvider.cs
+++ b/ClockifyExport.Cli/Export/ExporterProvider.cs
@@ -7,7 +7,7 @@ namespace ClockifyExport.Cli.Export;
 /// </summary>
 /// <param name="csvExporter">Injected CSV <see cref="IExporter"/> instance.</param>
 /// <param name="jsonExporter">Injected JSON <see cref="IExporter"/> instance.</param>
-public class ExporterProvider(
+internal sealed class ExporterProvider(
     [FromKeyedServices(ExportFormat.Csv)] IExporter csvExporter,
     [FromKeyedServices(ExportFormat.Json)] IExporter jsonExporter
 )

--- a/ClockifyExport.Cli/Export/IExporter.cs
+++ b/ClockifyExport.Cli/Export/IExporter.cs
@@ -5,7 +5,7 @@ namespace ClockifyExport.Cli.Export;
 /// <summary>
 /// Exports data to a string.
 /// </summary>
-public interface IExporter
+internal interface IExporter
 {
     /// <summary>
     /// Exports the given time entries to a string.

--- a/ClockifyExport.Cli/Export/JsonExporter.cs
+++ b/ClockifyExport.Cli/Export/JsonExporter.cs
@@ -6,7 +6,7 @@ namespace ClockifyExport.Cli.Export;
 /// <summary>
 /// Exports data to a JSON string.
 /// </summary>
-public class JsonExporter : IExporter
+internal sealed class JsonExporter : IExporter
 {
     private static readonly JsonSerializerOptions options =
         new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };

--- a/ClockifyExport.Cli/Logging/LoggerExtensions.cs
+++ b/ClockifyExport.Cli/Logging/LoggerExtensions.cs
@@ -6,7 +6,7 @@ namespace ClockifyExport.Cli.Logging;
 /// <summary>
 /// Strongly typed logger extensions.
 /// </summary>
-public static partial class LoggerExtensions
+internal static partial class LoggerExtensions
 {
     /// <summary>
     /// Logs a time entry validation error.

--- a/ClockifyExport.Cli/Processing/GroupedTimeEntry.cs
+++ b/ClockifyExport.Cli/Processing/GroupedTimeEntry.cs
@@ -7,7 +7,7 @@
 /// <param name="Group">Project or task of the grouped time entry.</param>
 /// <param name="Hours">Sum of time for the grouped time entry, expressed as total hours (with decimal part).</param>
 /// <param name="Description">All descriptions for the grouped time entry, each in its own line.</param>
-public record class GroupedTimeEntry(
+internal sealed record class GroupedTimeEntry(
     string Date,
     string Group,
     double Hours,

--- a/ClockifyExport.Cli/Processing/ITimeEntryAggregator.cs
+++ b/ClockifyExport.Cli/Processing/ITimeEntryAggregator.cs
@@ -7,7 +7,7 @@ namespace ClockifyExport.Cli.Processing;
 /// <summary>
 /// Groups time entries from Clockify shared reports.
 /// </summary>
-public interface ITimeEntryAggregator
+internal interface ITimeEntryAggregator
 {
     /// <summary>
     /// Groups time entries by date and either project or task.

--- a/ClockifyExport.Cli/Processing/PostProcessors/IPostProcessor.cs
+++ b/ClockifyExport.Cli/Processing/PostProcessors/IPostProcessor.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Post-processor for grouped time entries.
 /// </summary>
-public interface IPostProcessor
+internal interface IPostProcessor
 {
     /// <summary>
     /// Processes a grouped time entry.

--- a/ClockifyExport.Cli/Processing/PostProcessors/RoundingPostProcessor.cs
+++ b/ClockifyExport.Cli/Processing/PostProcessors/RoundingPostProcessor.cs
@@ -4,7 +4,7 @@
 /// Rounds up the hours of a grouped time entry to the nearest multiple of a given number of minutes.
 /// </summary>
 /// <param name="roundUpToMinutes">The number of minutes to round up to.</param>
-public class RoundingPostProcessor(int roundUpToMinutes) : IPostProcessor
+internal sealed class RoundingPostProcessor(int roundUpToMinutes) : IPostProcessor
 {
     /// <inheritdoc/>
     public GroupedTimeEntry Process(GroupedTimeEntry entry)

--- a/ClockifyExport.Cli/Processing/PreProcessors/IPreProcessor.cs
+++ b/ClockifyExport.Cli/Processing/PreProcessors/IPreProcessor.cs
@@ -5,7 +5,7 @@ namespace ClockifyExport.Cli.Processing.PreProcessors;
 /// <summary>
 /// Pre-processor for time entries.
 /// </summary>
-public interface IPreProcessor
+internal interface IPreProcessor
 {
     /// <summary>
     /// Processes a time entry before it is grouped.

--- a/ClockifyExport.Cli/Processing/PreProcessors/ParseTaskPreProcessor.cs
+++ b/ClockifyExport.Cli/Processing/PreProcessors/ParseTaskPreProcessor.cs
@@ -11,7 +11,8 @@ namespace ClockifyExport.Cli.Processing.PreProcessors;
 /// Regular expression to use for parsing.
 /// Full match should be the task id to parse.
 /// </param>
-public class ParseTaskPreProcessor([StringSyntax("Regex")] string regexPattern) : IPreProcessor
+internal sealed class ParseTaskPreProcessor([StringSyntax("Regex")] string regexPattern)
+    : IPreProcessor
 {
     private readonly Regex regex = new(regexPattern, RegexOptions.Compiled);
 

--- a/ClockifyExport.Cli/Processing/TimeEntryAggregator.cs
+++ b/ClockifyExport.Cli/Processing/TimeEntryAggregator.cs
@@ -10,7 +10,8 @@ namespace ClockifyExport.Cli.Processing;
 /// Groups time entries from Clockify shared reports.
 /// </summary>
 /// <param name="logger">Injected <see cref="ILogger"/> instance.</param>
-public class TimeEntryAggregator(ILogger<TimeEntryAggregator> logger) : ITimeEntryAggregator
+internal sealed class TimeEntryAggregator(ILogger<TimeEntryAggregator> logger)
+    : ITimeEntryAggregator
 {
     private readonly List<IPreProcessor> preProcessors = [];
     private readonly List<IPostProcessor> postProcessors = [];

--- a/ClockifyExport.Cli/Processing/TimeEntryGrouping.cs
+++ b/ClockifyExport.Cli/Processing/TimeEntryGrouping.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Indicates how time entries should be grouped.
 /// </summary>
-public enum TimeEntryGrouping
+internal enum TimeEntryGrouping
 {
     /// <summary>
     /// Group time entries by task.

--- a/ClockifyExport.Cli/Program.cs
+++ b/ClockifyExport.Cli/Program.cs
@@ -1,10 +1,17 @@
-﻿using ClockifyExport.Cli;
+﻿using System.Runtime.CompilerServices;
+using ClockifyExport.Cli;
 using ClockifyExport.Cli.Clockify;
 using ClockifyExport.Cli.Export;
 using ClockifyExport.Cli.Processing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+
+[assembly: InternalsVisibleTo("ClockifyExport.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+[assembly: InternalsVisibleTo(
+    "DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7"
+)]
 
 return await Host.CreateDefaultBuilder()
     .ConfigureServices(ConfigureServices)

--- a/ClockifyExport.Cli/Validation/FactorOfAttribute.cs
+++ b/ClockifyExport.Cli/Validation/FactorOfAttribute.cs
@@ -6,7 +6,7 @@ namespace ClockifyExport.Cli.Validation;
 /// Validation attribute to indicate that a property, field or parameter must be a factor of a given number.
 /// </summary>
 /// <param name="n">The number the value must be a factor of.</param>
-public sealed class FactorOfAttribute(int n)
+internal sealed class FactorOfAttribute(int n)
     : ValidationAttribute(() => $$"""The {0} field must be a factor of {{n}}.""")
 {
     /// <summary>

--- a/ClockifyExport.Tests/Clockify/ApiClientTests.cs
+++ b/ClockifyExport.Tests/Clockify/ApiClientTests.cs
@@ -7,7 +7,7 @@ using Moq.Contrib.HttpClient;
 
 namespace ClockifyExport.Tests.Clockify;
 
-public class ApiClientTests
+internal sealed class ApiClientTests
 {
     [Test]
     public async Task BuildsCorrectSharedReportUrl()

--- a/ClockifyExport.Tests/Clockify/CsvParserTests.cs
+++ b/ClockifyExport.Tests/Clockify/CsvParserTests.cs
@@ -4,7 +4,7 @@ using FluentAssertions;
 
 namespace ClockifyExport.Tests.Clockify;
 
-public class CsvParserTests
+internal sealed class CsvParserTests
 {
     [Test]
     public void ParsesCsvWithTask()

--- a/ClockifyExport.Tests/E2E/IntegrationTests.cs
+++ b/ClockifyExport.Tests/E2E/IntegrationTests.cs
@@ -7,7 +7,7 @@ using WireMock.Server;
 
 namespace ClockifyExport.Tests.E2E;
 
-public class IntegrationTests
+internal sealed class IntegrationTests
 {
     private WireMockServer server;
 

--- a/ClockifyExport.Tests/Export/ExporterTests.cs
+++ b/ClockifyExport.Tests/Export/ExporterTests.cs
@@ -6,7 +6,7 @@ using FluentAssertions;
 
 namespace ClockifyExport.Tests.Export;
 
-public class ExporterTests
+internal sealed class ExporterTests
 {
     private static readonly GroupedTimeEntry[] timeEntries =
     [

--- a/ClockifyExport.Tests/Processing/PostProcessors/RoundingPostProcessorTests.cs
+++ b/ClockifyExport.Tests/Processing/PostProcessors/RoundingPostProcessorTests.cs
@@ -4,7 +4,7 @@ using FluentAssertions;
 
 namespace ClockifyExport.Tests.Processing.PostProcessors;
 
-public class RoundingPostProcessorTests
+internal sealed class RoundingPostProcessorTests
 {
     [Test]
     [TestCase(0.01, 15)]

--- a/ClockifyExport.Tests/Processing/PreProcessors/ParseTaskPreProcessorTests.cs
+++ b/ClockifyExport.Tests/Processing/PreProcessors/ParseTaskPreProcessorTests.cs
@@ -4,7 +4,7 @@ using FluentAssertions;
 
 namespace ClockifyExport.Tests.Processing.PreProcessors;
 
-public class ParseTaskPreProcessorTests
+internal sealed class ParseTaskPreProcessorTests
 {
     [Test]
     [TestCase("JIRA-1234: Do something", "JIRA-1234", null)]

--- a/ClockifyExport.Tests/Processing/TimeEntryAggregatorTests.cs
+++ b/ClockifyExport.Tests/Processing/TimeEntryAggregatorTests.cs
@@ -10,7 +10,7 @@ using Moq.AutoMock;
 
 namespace ClockifyExport.Tests.Processing;
 
-public class TimeEntryAggregatorTests
+internal sealed class TimeEntryAggregatorTests
 {
     private static readonly List<ClockifyTimeEntry> timeEntries =
     [
@@ -51,7 +51,7 @@ public class TimeEntryAggregatorTests
     public void AggregatesTimeEntriesByProject()
     {
         var mocker = new AutoMocker();
-        var aggregator = mocker.Get<TimeEntryAggregator>();
+        var aggregator = mocker.CreateInstance<TimeEntryAggregator>();
 
         var groupedTimeEntries = aggregator.Aggregate(timeEntries, TimeEntryGrouping.ByProject);
 
@@ -109,7 +109,7 @@ public class TimeEntryAggregatorTests
     public void ThrowsForUnknownGrouping()
     {
         var mocker = new AutoMocker();
-        var aggregator = mocker.Get<TimeEntryAggregator>();
+        var aggregator = mocker.CreateInstance<TimeEntryAggregator>();
 
         Action action = () => aggregator.Aggregate(timeEntries, (TimeEntryGrouping)42);
 
@@ -189,7 +189,7 @@ public class TimeEntryAggregatorTests
     public void ExecutesAllPostProcessorsOnAllGroupedEntries()
     {
         var mocker = new AutoMocker();
-        var aggregator = mocker.Get<TimeEntryAggregator>();
+        var aggregator = mocker.CreateInstance<TimeEntryAggregator>();
 
         var postProcessor1Mock = new Mock<IPostProcessor>();
         postProcessor1Mock

--- a/ClockifyExport.Tests/Validation/FactorOfAttributeTests.cs
+++ b/ClockifyExport.Tests/Validation/FactorOfAttributeTests.cs
@@ -3,7 +3,7 @@ using FluentAssertions;
 
 namespace ClockifyExport.Tests.Validation;
 
-public class FactorOfAttributeTests
+internal sealed class FactorOfAttributeTests
 {
     [Test]
     [TestCase(1, 60)]


### PR DESCRIPTION
[CA1515](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1515) warning was introduced with .NET 9 SDK. Fixing it also required the following changes:
- Making application internals visible to the test project and the mocking framework.
- Also fixing the resulting [CA1852](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1852) warnings in the test project

CA1852 analysis is disabled by default in assemblies with `InternalsVisibleTo` attribute. I reenabled the analysis for the application assembly in `.editorconfig` file and fixed all resulting occurrences of the warning.